### PR TITLE
Fix #2: Add range request support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 1.1.1 under development
 
-- no changes in this release.
+- New #2: Add range request support (@samdark)
 
 ## 1.1.0 April 09, 2026
 

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ served.
 - If mime type is omitted, for `sendContentAsFile()`, `sendFile()` and `xSendFile()` it will be determined based on
 the file content. For other methods or when unable to determine the mime type, "application/octet-stream" will be used.
 - Content disposition is "attachment" by default. It will trigger browser's download dialog. If you want the content
-of the file to be displayed inline, set it to `Yiisoft\Http\ContentDispositionHeader\ContentDispositionHeader::INLINE`.
+of the file to be displayed inline, set it to `Yiisoft\Http\ContentDispositionHeader::INLINE`.
 - To support HTTP range requests, pass a PSR-7 server request as the `request` argument to `sendContentAsFile()`,
 `sendFile()` or `sendStreamAsFile()`. Single byte ranges are supported when the response body size is known and the
 stream is seekable. Multiple ranges are ignored and the full response is returned. For `xSendFile()`, range handling is

--- a/README.md
+++ b/README.md
@@ -119,6 +119,10 @@ served.
 the file content. For other methods or when unable to determine the mime type, "application/octet-stream" will be used.
 - Content disposition is "attachment" by default. It will trigger browser's download dialog. If you want the content
 of the file to be displayed inline, set it to `Yiisoft\Http\ContentDispositionHeader\ContentDispositionHeader::INLINE`.
+- To support HTTP range requests, pass a PSR-7 server request as the `request` argument to `sendContentAsFile()`,
+`sendFile()` or `sendStreamAsFile()`. Single byte ranges are supported when the response body size is known and the
+stream is seekable. Multiple ranges are ignored and the full response is returned. For `xSendFile()`, range handling is
+delegated to the web server.
 
 ## Documentation
 

--- a/psalm.xml
+++ b/psalm.xml
@@ -15,6 +15,7 @@
     </projectFiles>
     <issueHandlers>
         <MixedAssignment errorLevel="suppress" />
+        <MissingOverrideAttribute errorLevel="suppress" />
         <RiskyTruthyFalsyComparison errorLevel="suppress" />
     </issueHandlers>
 </psalm>

--- a/src/ByteRangeStream.php
+++ b/src/ByteRangeStream.php
@@ -47,43 +47,36 @@ final class ByteRangeStream implements StreamInterface
         }
     }
 
-    #[\Override]
     public function close(): void
     {
         $this->stream->close();
     }
 
-    #[\Override]
     public function detach()
     {
         return $this->stream->detach();
     }
 
-    #[\Override]
     public function getSize(): ?int
     {
         return $this->size;
     }
 
-    #[\Override]
     public function tell(): int
     {
         return $this->position;
     }
 
-    #[\Override]
     public function eof(): bool
     {
         return $this->position >= $this->size || $this->stream->eof();
     }
 
-    #[\Override]
     public function isSeekable(): bool
     {
         return $this->stream->isSeekable();
     }
 
-    #[\Override]
     public function seek(int $offset, int $whence = SEEK_SET): void
     {
         $position = match ($whence) {
@@ -101,31 +94,26 @@ final class ByteRangeStream implements StreamInterface
         $this->position = $position;
     }
 
-    #[\Override]
     public function rewind(): void
     {
         $this->seek(0);
     }
 
-    #[\Override]
     public function isWritable(): bool
     {
         return false;
     }
 
-    #[\Override]
     public function write(string $string): int
     {
         throw new RuntimeException('Stream is not writable.');
     }
 
-    #[\Override]
     public function isReadable(): bool
     {
         return $this->stream->isReadable();
     }
 
-    #[\Override]
     public function read(int $length): string
     {
         if ($length < 0) {
@@ -143,7 +131,6 @@ final class ByteRangeStream implements StreamInterface
         return $contents;
     }
 
-    #[\Override]
     public function getContents(): string
     {
         $contents = [];
@@ -161,7 +148,6 @@ final class ByteRangeStream implements StreamInterface
         return implode('', $contents);
     }
 
-    #[\Override]
     public function getMetadata(?string $key = null)
     {
         return $this->stream->getMetadata($key);

--- a/src/ByteRangeStream.php
+++ b/src/ByteRangeStream.php
@@ -6,6 +6,7 @@ namespace Yiisoft\ResponseDownload;
 
 use Psr\Http\Message\StreamInterface;
 use RuntimeException;
+use Throwable;
 
 use const SEEK_CUR;
 use const SEEK_END;
@@ -41,41 +42,48 @@ final class ByteRangeStream implements StreamInterface
         try {
             $this->rewind();
             return $this->getContents();
-        } catch (RuntimeException) {
+        } catch (Throwable) {
             return '';
         }
     }
 
+    #[\Override]
     public function close(): void
     {
         $this->stream->close();
     }
 
+    #[\Override]
     public function detach()
     {
         return $this->stream->detach();
     }
 
+    #[\Override]
     public function getSize(): ?int
     {
         return $this->size;
     }
 
+    #[\Override]
     public function tell(): int
     {
         return $this->position;
     }
 
+    #[\Override]
     public function eof(): bool
     {
         return $this->position >= $this->size || $this->stream->eof();
     }
 
+    #[\Override]
     public function isSeekable(): bool
     {
         return $this->stream->isSeekable();
     }
 
+    #[\Override]
     public function seek(int $offset, int $whence = SEEK_SET): void
     {
         $position = match ($whence) {
@@ -93,26 +101,31 @@ final class ByteRangeStream implements StreamInterface
         $this->position = $position;
     }
 
+    #[\Override]
     public function rewind(): void
     {
         $this->seek(0);
     }
 
+    #[\Override]
     public function isWritable(): bool
     {
         return false;
     }
 
+    #[\Override]
     public function write(string $string): int
     {
         throw new RuntimeException('Stream is not writable.');
     }
 
+    #[\Override]
     public function isReadable(): bool
     {
         return $this->stream->isReadable();
     }
 
+    #[\Override]
     public function read(int $length): string
     {
         if ($length < 0) {
@@ -130,17 +143,25 @@ final class ByteRangeStream implements StreamInterface
         return $contents;
     }
 
+    #[\Override]
     public function getContents(): string
     {
-        $contents = '';
+        $contents = [];
 
         while (!$this->eof()) {
-            $contents .= $this->read(8192);
+            $chunk = $this->read(8192);
+
+            if ($chunk === '') {
+                break;
+            }
+
+            $contents[] = $chunk;
         }
 
-        return $contents;
+        return implode('', $contents);
     }
 
+    #[\Override]
     public function getMetadata(?string $key = null)
     {
         return $this->stream->getMetadata($key);

--- a/src/ByteRangeStream.php
+++ b/src/ByteRangeStream.php
@@ -1,0 +1,148 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\ResponseDownload;
+
+use Psr\Http\Message\StreamInterface;
+use RuntimeException;
+
+use const SEEK_CUR;
+use const SEEK_END;
+use const SEEK_SET;
+
+/**
+ * @internal
+ */
+final class ByteRangeStream implements StreamInterface
+{
+    private int $position = 0;
+    private readonly int $size;
+
+    public function __construct(
+        private readonly StreamInterface $stream,
+        private readonly int $start,
+        private readonly int $end,
+    ) {
+        if ($start < 0 || $end < $start) {
+            throw new RuntimeException('Invalid byte range.');
+        }
+
+        if (!$stream->isSeekable()) {
+            throw new RuntimeException('Stream is not seekable.');
+        }
+
+        $this->size = $end - $start + 1;
+        $this->stream->seek($start);
+    }
+
+    public function __toString(): string
+    {
+        try {
+            $this->rewind();
+            return $this->getContents();
+        } catch (RuntimeException) {
+            return '';
+        }
+    }
+
+    public function close(): void
+    {
+        $this->stream->close();
+    }
+
+    public function detach()
+    {
+        return $this->stream->detach();
+    }
+
+    public function getSize(): ?int
+    {
+        return $this->size;
+    }
+
+    public function tell(): int
+    {
+        return $this->position;
+    }
+
+    public function eof(): bool
+    {
+        return $this->position >= $this->size || $this->stream->eof();
+    }
+
+    public function isSeekable(): bool
+    {
+        return $this->stream->isSeekable();
+    }
+
+    public function seek(int $offset, int $whence = SEEK_SET): void
+    {
+        $position = match ($whence) {
+            SEEK_SET => $offset,
+            SEEK_CUR => $this->position + $offset,
+            SEEK_END => $this->size + $offset,
+            default => throw new RuntimeException('Invalid seek mode.'),
+        };
+
+        if ($position < 0 || $position > $this->size) {
+            throw new RuntimeException('Invalid seek offset.');
+        }
+
+        $this->stream->seek($this->start + $position);
+        $this->position = $position;
+    }
+
+    public function rewind(): void
+    {
+        $this->seek(0);
+    }
+
+    public function isWritable(): bool
+    {
+        return false;
+    }
+
+    public function write(string $string): int
+    {
+        throw new RuntimeException('Stream is not writable.');
+    }
+
+    public function isReadable(): bool
+    {
+        return $this->stream->isReadable();
+    }
+
+    public function read(int $length): string
+    {
+        if ($length < 0) {
+            throw new RuntimeException('Length parameter cannot be negative.');
+        }
+
+        if ($length === 0 || $this->eof()) {
+            return '';
+        }
+
+        $remaining = $this->size - $this->position;
+        $contents = $this->stream->read(min($length, $remaining));
+        $this->position += strlen($contents);
+
+        return $contents;
+    }
+
+    public function getContents(): string
+    {
+        $contents = '';
+
+        while (!$this->eof()) {
+            $contents .= $this->read(8192);
+        }
+
+        return $contents;
+    }
+
+    public function getMetadata(?string $key = null)
+    {
+        return $this->stream->getMetadata($key);
+    }
+}

--- a/src/ByteRangeStream.php
+++ b/src/ByteRangeStream.php
@@ -23,7 +23,7 @@ final class ByteRangeStream implements StreamInterface
     public function __construct(
         private readonly StreamInterface $stream,
         private readonly int $start,
-        private readonly int $end,
+        int $end,
     ) {
         if ($start < 0 || $end < $start) {
             throw new RuntimeException('Invalid byte range.');
@@ -31,6 +31,10 @@ final class ByteRangeStream implements StreamInterface
 
         if (!$stream->isSeekable()) {
             throw new RuntimeException('Stream is not seekable.');
+        }
+
+        if (!$stream->isReadable()) {
+            throw new RuntimeException('Stream is not readable.');
         }
 
         $this->size = $end - $start + 1;
@@ -74,7 +78,7 @@ final class ByteRangeStream implements StreamInterface
 
     public function isSeekable(): bool
     {
-        return $this->stream->isSeekable();
+        return true;
     }
 
     public function seek(int $offset, int $whence = SEEK_SET): void
@@ -111,7 +115,7 @@ final class ByteRangeStream implements StreamInterface
 
     public function isReadable(): bool
     {
-        return $this->stream->isReadable();
+        return true;
     }
 
     public function read(int $length): string

--- a/src/DownloadResponseFactory.php
+++ b/src/DownloadResponseFactory.php
@@ -210,18 +210,18 @@ final class DownloadResponseFactory
      */
     private function parseByteRange(string $rangeHeader, int $size): array|false|null
     {
-        if (!str_starts_with($rangeHeader, self::RANGE_UNIT_BYTES . '=')) {
+        if (!preg_match('/^' . self::RANGE_UNIT_BYTES . '=(.*)$/i', $rangeHeader, $unitMatches)) {
             return false;
         }
 
-        $range = substr($rangeHeader, strlen(self::RANGE_UNIT_BYTES . '='));
+        $range = $unitMatches[1];
 
         if ($range === '' || str_contains($range, ',')) {
             return false;
         }
 
         if (!preg_match('/^(\d*)-(\d*)$/', $range, $matches)) {
-            return null;
+            return false;
         }
 
         [, $start, $end] = $matches;

--- a/src/DownloadResponseFactory.php
+++ b/src/DownloadResponseFactory.php
@@ -24,10 +24,6 @@ final class DownloadResponseFactory
      * @see https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types#applicationoctet-stream
      */
     private const MIME_APPLICATION_OCTET_STREAM = 'application/octet-stream';
-    private const HEADER_ACCEPT_RANGES = 'Accept-Ranges';
-    private const HEADER_CONTENT_LENGTH = 'Content-Length';
-    private const HEADER_CONTENT_RANGE = 'Content-Range';
-    private const HEADER_RANGE = 'Range';
     private const RANGE_UNIT_BYTES = 'bytes';
 
     /**
@@ -139,7 +135,7 @@ final class DownloadResponseFactory
             )
             ->withBody($stream);
 
-        return $this->withRangeSupport($response, $stream, $request);
+        return $this->processRange($response, $stream, $request);
     }
 
     /**
@@ -259,7 +255,7 @@ final class DownloadResponseFactory
         return [$startPosition, min($endPosition, $size - 1)];
     }
 
-    private function withRangeSupport(
+    private function processRange(
         ResponseInterface $response,
         StreamInterface $stream,
         ?ServerRequestInterface $request,
@@ -270,17 +266,17 @@ final class DownloadResponseFactory
 
         $size = $stream->getSize();
 
-        if ($size === null || !$stream->isSeekable()) {
+        if ($size === null || !$stream->isSeekable() || !$stream->isReadable()) {
             return $response;
         }
 
         $stream->rewind();
 
         $response = $response
-            ->withHeader(self::HEADER_ACCEPT_RANGES, self::RANGE_UNIT_BYTES)
-            ->withHeader(self::HEADER_CONTENT_LENGTH, (string) $size);
+            ->withHeader(Header::ACCEPT_RANGES, self::RANGE_UNIT_BYTES)
+            ->withHeader(Header::CONTENT_LENGTH, (string) $size);
 
-        $rangeHeader = trim($request->getHeaderLine(self::HEADER_RANGE));
+        $rangeHeader = trim($request->getHeaderLine(Header::RANGE));
 
         $range = $this->parseByteRange($rangeHeader, $size);
 
@@ -291,8 +287,8 @@ final class DownloadResponseFactory
         if ($range === null) {
             return $response
                 ->withStatus(416)
-                ->withHeader(self::HEADER_CONTENT_RANGE, self::RANGE_UNIT_BYTES . ' */' . $size)
-                ->withHeader(self::HEADER_CONTENT_LENGTH, '0')
+                ->withHeader(Header::CONTENT_RANGE, self::RANGE_UNIT_BYTES . ' */' . $size)
+                ->withHeader(Header::CONTENT_LENGTH, '0')
                 ->withBody($this->streamFactory->createStream());
         }
 
@@ -302,10 +298,10 @@ final class DownloadResponseFactory
         return $response
             ->withStatus(206)
             ->withHeader(
-                self::HEADER_CONTENT_RANGE,
+                Header::CONTENT_RANGE,
                 sprintf('%s %d-%d/%d', self::RANGE_UNIT_BYTES, $start, $end, $size),
             )
-            ->withHeader(self::HEADER_CONTENT_LENGTH, (string) $length)
+            ->withHeader(Header::CONTENT_LENGTH, (string) $length)
             ->withBody(new ByteRangeStream($stream, $start, $end));
     }
 

--- a/src/DownloadResponseFactory.php
+++ b/src/DownloadResponseFactory.php
@@ -227,7 +227,7 @@ final class DownloadResponseFactory
         [, $start, $end] = $matches;
 
         if ($start === '' && $end === '') {
-            return null;
+            return false;
         }
 
         if ($start === '') {

--- a/src/DownloadResponseFactory.php
+++ b/src/DownloadResponseFactory.php
@@ -274,6 +274,8 @@ final class DownloadResponseFactory
             return $response;
         }
 
+        $stream->rewind();
+
         $response = $response
             ->withHeader(self::HEADER_ACCEPT_RANGES, self::RANGE_UNIT_BYTES)
             ->withHeader(self::HEADER_CONTENT_LENGTH, (string) $size);

--- a/src/DownloadResponseFactory.php
+++ b/src/DownloadResponseFactory.php
@@ -8,6 +8,7 @@ use finfo;
 use InvalidArgumentException;
 use Psr\Http\Message\ResponseFactoryInterface;
 use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Message\StreamInterface;
 use Yiisoft\Http\ContentDispositionHeader;
@@ -23,6 +24,11 @@ final class DownloadResponseFactory
      * @see https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types#applicationoctet-stream
      */
     private const MIME_APPLICATION_OCTET_STREAM = 'application/octet-stream';
+    private const HEADER_ACCEPT_RANGES = 'Accept-Ranges';
+    private const HEADER_CONTENT_LENGTH = 'Content-Length';
+    private const HEADER_CONTENT_RANGE = 'Content-Range';
+    private const HEADER_RANGE = 'Range';
+    private const RANGE_UNIT_BYTES = 'bytes';
 
     /**
      * @param ResponseFactoryInterface $responseFactory PSR-17 compatible response factory
@@ -110,6 +116,8 @@ final class DownloadResponseFactory
      * @param string $disposition Content disposition. Either {@see ContentDispositionHeader::ATTACHMENT}
      * or {@see ContentDispositionHeader::INLINE}. Default is {@see ContentDispositionHeader::ATTACHMENT}.
      * @param string $mimeType The MIME type of the content. Default is {@see MIME_APPLICATION_OCTET_STREAM}.
+     * @param ServerRequestInterface|null $request The request to read the `Range` header from. If `null`, range
+     * requests are not handled.
      *
      * @return ResponseInterface PSR-7 compatible response
      * (@see https://www.php-fig.org/psr/psr-7/#33-psrhttpmessageresponseinterface).
@@ -119,16 +127,19 @@ final class DownloadResponseFactory
         string $attachmentName,
         string $disposition = ContentDispositionHeader::ATTACHMENT,
         string $mimeType = self::MIME_APPLICATION_OCTET_STREAM,
+        ?ServerRequestInterface $request = null,
     ): ResponseInterface {
         $this->assertDisposition($disposition);
 
-        return $this->responseFactory->createResponse()
+        $response = $this->responseFactory->createResponse()
             ->withHeader(Header::CONTENT_TYPE, $mimeType)
             ->withHeader(
                 ContentDispositionHeader::name(),
                 ContentDispositionHeader::value($disposition, $attachmentName),
             )
             ->withBody($stream);
+
+        return $this->withRangeSupport($response, $stream, $request);
     }
 
     /**
@@ -141,6 +152,8 @@ final class DownloadResponseFactory
      * or {@see ContentDispositionHeader::INLINE}. Default is {@see ContentDispositionHeader::ATTACHMENT}.
      * @param string|null $mimeType The MIME type of the content. If not set, it will be guessed based on the file
      * content ({@see $filePath}).
+     * @param ServerRequestInterface|null $request The request to read the `Range` header from. If `null`, range
+     * requests are not handled.
      *
      * @return ResponseInterface PSR-7 compatible response
      * (@see https://www.php-fig.org/psr/psr-7/#33-psrhttpmessageresponseinterface).
@@ -150,12 +163,14 @@ final class DownloadResponseFactory
         ?string $attachmentName = null,
         string $disposition = ContentDispositionHeader::ATTACHMENT,
         ?string $mimeType = null,
+        ?ServerRequestInterface $request = null,
     ): ResponseInterface {
         return $this->sendStreamAsFile(
             stream: $this->streamFactory->createStreamFromFile($filePath),
             attachmentName: $attachmentName ?? basename($filePath),
             disposition: $disposition,
             mimeType: $mimeType ?? $this->getFileMimeType($filePath),
+            request: $request,
         );
     }
 
@@ -168,6 +183,8 @@ final class DownloadResponseFactory
      * or {@see ContentDispositionHeader::INLINE}. Default is {@see ContentDispositionHeader::ATTACHMENT}.
      * @param string|null $mimeType The MIME type of the content. If not set, it will be guessed based on the
      * {@see $content}.
+     * @param ServerRequestInterface|null $request The request to read the `Range` header from. If `null`, range
+     * requests are not handled.
      *
      * @return ResponseInterface PSR-7 compatible response
      * (@see https://www.php-fig.org/psr/psr-7/#33-psrhttpmessageresponseinterface).
@@ -177,13 +194,121 @@ final class DownloadResponseFactory
         string $attachmentName,
         string $disposition = ContentDispositionHeader::ATTACHMENT,
         ?string $mimeType = null,
+        ?ServerRequestInterface $request = null,
     ): ResponseInterface {
         return $this->sendStreamAsFile(
             stream: $this->streamFactory->createStream($content),
             attachmentName: $attachmentName,
             disposition: $disposition,
             mimeType: $mimeType ?? $this->getContentMimeType($content),
+            request: $request,
         );
+    }
+
+    /**
+     * @return array{int, int}|false|null `false` means unsupported range, `null` means unsatisfiable range.
+     */
+    private function parseByteRange(string $rangeHeader, int $size): array|false|null
+    {
+        if (!str_starts_with($rangeHeader, self::RANGE_UNIT_BYTES . '=')) {
+            return false;
+        }
+
+        $range = substr($rangeHeader, strlen(self::RANGE_UNIT_BYTES . '='));
+
+        if ($range === '' || str_contains($range, ',')) {
+            return false;
+        }
+
+        if (!preg_match('/^(\d*)-(\d*)$/', $range, $matches)) {
+            return null;
+        }
+
+        [, $start, $end] = $matches;
+
+        if ($start === '' && $end === '') {
+            return null;
+        }
+
+        if ($start === '') {
+            $suffixLength = (int) $end;
+
+            if ($suffixLength <= 0) {
+                return null;
+            }
+
+            if ($suffixLength >= $size) {
+                return $size === 0 ? null : [0, $size - 1];
+            }
+
+            return [$size - $suffixLength, $size - 1];
+        }
+
+        $startPosition = (int) $start;
+
+        if ($startPosition >= $size) {
+            return null;
+        }
+
+        $endPosition = $end === '' ? $size - 1 : (int) $end;
+
+        if ($endPosition < $startPosition) {
+            return null;
+        }
+
+        return [$startPosition, min($endPosition, $size - 1)];
+    }
+
+    private function withRangeSupport(
+        ResponseInterface $response,
+        StreamInterface $stream,
+        ?ServerRequestInterface $request,
+    ): ResponseInterface {
+        if ($request === null) {
+            return $response;
+        }
+
+        $size = $stream->getSize();
+
+        if ($size === null || !$stream->isSeekable()) {
+            return $response;
+        }
+
+        $response = $response
+            ->withHeader(self::HEADER_ACCEPT_RANGES, self::RANGE_UNIT_BYTES)
+            ->withHeader(self::HEADER_CONTENT_LENGTH, (string) $size);
+
+        $rangeHeader = trim($request->getHeaderLine(self::HEADER_RANGE));
+
+        if ($rangeHeader === '') {
+            return $response;
+        }
+
+        $range = $this->parseByteRange($rangeHeader, $size);
+
+        if ($range === false) {
+            return $response;
+        }
+
+        if ($range === null) {
+            return $response
+                ->withStatus(416)
+                ->withHeader(self::HEADER_CONTENT_RANGE, self::RANGE_UNIT_BYTES . ' */' . $size)
+                ->withHeader(self::HEADER_CONTENT_LENGTH, '0')
+                ->withBody($this->streamFactory->createStream());
+        }
+
+        [$start, $end] = $range;
+        $length = $end - $start + 1;
+
+        return $response
+            ->withStatus(206)
+            ->withHeader(
+                self::HEADER_CONTENT_RANGE,
+                sprintf('%s %d-%d/%d', self::RANGE_UNIT_BYTES, $start, $end, $size),
+            )
+            ->withHeader(self::HEADER_CONTENT_LENGTH, (string) $length)
+            ->withBody(new ByteRangeStream($stream, $start, $end));
     }
 
     /**

--- a/src/DownloadResponseFactory.php
+++ b/src/DownloadResponseFactory.php
@@ -216,10 +216,6 @@ final class DownloadResponseFactory
 
         $range = $unitMatches[1];
 
-        if ($range === '' || str_contains($range, ',')) {
-            return false;
-        }
-
         if (!preg_match('/^(\d*)-(\d*)$/', $range, $matches)) {
             return false;
         }
@@ -237,7 +233,7 @@ final class DownloadResponseFactory
                 return null;
             }
 
-            if ($suffixLength >= $size) {
+            if ($suffixLength > $size) {
                 return $size === 0 ? null : [0, $size - 1];
             }
 
@@ -250,7 +246,11 @@ final class DownloadResponseFactory
             return null;
         }
 
-        $endPosition = $end === '' ? $size - 1 : (int) $end;
+        if ($end === '') {
+            return [$startPosition, $size - 1];
+        }
+
+        $endPosition = (int) $end;
 
         if ($endPosition < $startPosition) {
             return null;
@@ -281,10 +281,6 @@ final class DownloadResponseFactory
             ->withHeader(self::HEADER_CONTENT_LENGTH, (string) $size);
 
         $rangeHeader = trim($request->getHeaderLine(self::HEADER_RANGE));
-
-        if ($rangeHeader === '') {
-            return $response;
-        }
 
         $range = $this->parseByteRange($rangeHeader, $size);
 

--- a/tests/DownloadResponseFactoryTest.php
+++ b/tests/DownloadResponseFactoryTest.php
@@ -135,6 +135,32 @@ final class DownloadResponseFactoryTest extends TestCase
         $responseFactory->sendStreamAsFile($stream, attachmentName: 'answer.txt', disposition: 'a');
     }
 
+    public function testSendStreamAsFileWithRangeRequestRewindsStream(): void
+    {
+        $stream = (new StreamFactory())->createStream('abcdef');
+        $stream->seek(3);
+
+        $response = $this
+            ->getDownloadResponseFactory()
+            ->sendStreamAsFile(
+                $stream,
+                'alphabet.txt',
+                mimeType: 'text/plain',
+                request: $this->createRequest('bytes=1-3'),
+            );
+
+        $this->assertSame(206, $response->getStatusCode());
+        $this->assertResponseHeaders(
+            [
+                'Accept-Ranges' => 'bytes',
+                'Content-Range' => 'bytes 1-3/6',
+                'Content-Length' => '3',
+            ],
+            $response,
+        );
+        $this->assertSame('bcd', (string) $response->getBody());
+    }
+
     public static function dataSendFile(): array
     {
         $txtFilePath = self::getFilePath('answer.txt');

--- a/tests/DownloadResponseFactoryTest.php
+++ b/tests/DownloadResponseFactoryTest.php
@@ -204,7 +204,7 @@ final class DownloadResponseFactoryTest extends TestCase
     {
         $response = $this
             ->getDownloadResponseFactory()
-            ->sendFile(self::getFilePath('style.css'), request: $this->createRequest('bytes=7-15'));
+            ->sendFile(self::getFilePath('style.css'), mimeType: 'text/css', request: $this->createRequest('bytes=7-15'));
 
         $this->assertSame(206, $response->getStatusCode());
         $this->assertResponseHeaders(
@@ -236,6 +236,29 @@ final class DownloadResponseFactoryTest extends TestCase
             $response,
         );
         $this->assertSame("x; }\n", (string) $response->getBody());
+    }
+
+    public function testSendContentAsFileWithCaseInsensitiveRangeUnit(): void
+    {
+        $response = $this
+            ->getDownloadResponseFactory()
+            ->sendContentAsFile(
+                'abcdef',
+                'alphabet.txt',
+                mimeType: 'text/plain',
+                request: $this->createRequest('Bytes=1-3'),
+            );
+
+        $this->assertSame(206, $response->getStatusCode());
+        $this->assertResponseHeaders(
+            [
+                'Accept-Ranges' => 'bytes',
+                'Content-Range' => 'bytes 1-3/6',
+                'Content-Length' => '3',
+            ],
+            $response,
+        );
+        $this->assertSame('bcd', (string) $response->getBody());
     }
 
     public function testSendContentAsFileWithSuffixRangeRequest(): void
@@ -279,6 +302,29 @@ final class DownloadResponseFactoryTest extends TestCase
                 'Content-Length' => '6',
                 'Content-Disposition' => 'attachment; filename="alphabet.txt"',
                 'Content-Type' => 'text/plain',
+            ],
+            $response,
+        );
+        $this->assertSame('', $response->getHeaderLine('Content-Range'));
+        $this->assertSame('abcdef', (string) $response->getBody());
+    }
+
+    public function testSendContentAsFileWithMalformedRangeRequest(): void
+    {
+        $response = $this
+            ->getDownloadResponseFactory()
+            ->sendContentAsFile(
+                'abcdef',
+                'alphabet.txt',
+                mimeType: 'text/plain',
+                request: $this->createRequest('bytes=foo'),
+            );
+
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertResponseHeaders(
+            [
+                'Accept-Ranges' => 'bytes',
+                'Content-Length' => '6',
             ],
             $response,
         );

--- a/tests/DownloadResponseFactoryTest.php
+++ b/tests/DownloadResponseFactoryTest.php
@@ -179,6 +179,23 @@ final class DownloadResponseFactoryTest extends TestCase
         $this->assertSame('abcdef', (string) $response->getBody());
     }
 
+    public function testSendStreamAsFileWithRangeRequestDoesNotSupportNonReadableStream(): void
+    {
+        $response = $this
+            ->getDownloadResponseFactory()
+            ->sendStreamAsFile(
+                $this->createNonReadableSeekableStream('abcdef'),
+                'alphabet.txt',
+                mimeType: 'text/plain',
+                request: $this->createRequest('bytes=1-3'),
+            );
+
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('', $response->getHeaderLine('Accept-Ranges'));
+        $this->assertSame('', $response->getHeaderLine('Content-Length'));
+        $this->assertSame('abcdef', (string) $response->getBody());
+    }
+
     public function testSendStreamAsFileWithRequestWithoutRangeRewindsStream(): void
     {
         $stream = (new StreamFactory())->createStream('abcdef');
@@ -952,6 +969,102 @@ final class DownloadResponseFactoryTest extends TestCase
                 $this->position = strlen($this->content);
 
                 return $contents;
+            }
+
+            public function getMetadata(?string $key = null)
+            {
+                return $key === null ? [] : null;
+            }
+        };
+    }
+
+    private function createNonReadableSeekableStream(string $content): StreamInterface
+    {
+        return new class ($content) implements StreamInterface {
+            private int $position = 0;
+
+            public function __construct(private readonly string $content)
+            {
+            }
+
+            public function __toString(): string
+            {
+                return $this->content;
+            }
+
+            public function close(): void
+            {
+            }
+
+            public function detach()
+            {
+                return null;
+            }
+
+            public function getSize(): ?int
+            {
+                return strlen($this->content);
+            }
+
+            public function tell(): int
+            {
+                return $this->position;
+            }
+
+            public function eof(): bool
+            {
+                return $this->position >= strlen($this->content);
+            }
+
+            public function isSeekable(): bool
+            {
+                return true;
+            }
+
+            public function seek(int $offset, int $whence = SEEK_SET): void
+            {
+                $position = match ($whence) {
+                    SEEK_SET => $offset,
+                    SEEK_CUR => $this->position + $offset,
+                    SEEK_END => strlen($this->content) + $offset,
+                    default => throw new RuntimeException('Invalid seek mode.'),
+                };
+
+                if ($position < 0 || $position > strlen($this->content)) {
+                    throw new RuntimeException('Invalid seek offset.');
+                }
+
+                $this->position = $position;
+            }
+
+            public function rewind(): void
+            {
+                $this->seek(0);
+            }
+
+            public function isWritable(): bool
+            {
+                return false;
+            }
+
+            public function write(string $string): int
+            {
+                throw new RuntimeException('Stream is not writable.');
+            }
+
+            public function isReadable(): bool
+            {
+                return false;
+            }
+
+            public function read(int $length): string
+            {
+                throw new RuntimeException('Stream is not readable.');
+            }
+
+            public function getContents(): string
+            {
+                throw new RuntimeException('Stream is not readable.');
             }
 
             public function getMetadata(?string $key = null)

--- a/tests/DownloadResponseFactoryTest.php
+++ b/tests/DownloadResponseFactoryTest.php
@@ -11,6 +11,7 @@ use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\StreamInterface;
 use RuntimeException;
 use Yiisoft\Http\ContentDispositionHeader;
 use Yiisoft\ResponseDownload\DownloadResponseFactory;
@@ -161,6 +162,67 @@ final class DownloadResponseFactoryTest extends TestCase
         $this->assertSame('bcd', (string) $response->getBody());
     }
 
+    public function testSendStreamAsFileWithRangeRequestDoesNotSupportNonSeekableStream(): void
+    {
+        $response = $this
+            ->getDownloadResponseFactory()
+            ->sendStreamAsFile(
+                $this->createNonSeekableStream('abcdef'),
+                'alphabet.txt',
+                mimeType: 'text/plain',
+                request: $this->createRequest('bytes=1-3'),
+            );
+
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('', $response->getHeaderLine('Accept-Ranges'));
+        $this->assertSame('', $response->getHeaderLine('Content-Length'));
+        $this->assertSame('abcdef', (string) $response->getBody());
+    }
+
+    public function testSendStreamAsFileWithRequestWithoutRangeRewindsStream(): void
+    {
+        $stream = (new StreamFactory())->createStream('abcdef');
+        $stream->seek(3);
+
+        $response = $this
+            ->getDownloadResponseFactory()
+            ->sendStreamAsFile(
+                $stream,
+                'alphabet.txt',
+                mimeType: 'text/plain',
+                request: $this->createRequest(),
+            );
+
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertResponseHeaders(
+            [
+                'Accept-Ranges' => 'bytes',
+                'Content-Length' => '6',
+            ],
+            $response,
+        );
+        $this->assertSame('abcdef', (string) $response->getBody());
+    }
+
+    public function testSendStreamAsFileWithRequestWithoutRangeCanBeReadByEmitter(): void
+    {
+        $stream = (new StreamFactory())->createStream('abcdef');
+        $stream->seek(3);
+
+        $body = $this
+            ->getDownloadResponseFactory()
+            ->sendStreamAsFile(
+                $stream,
+                'alphabet.txt',
+                mimeType: 'text/plain',
+                request: $this->createRequest(),
+            )
+            ->getBody();
+
+        $this->assertSame('abc', $body->read(3));
+        $this->assertSame('def', $body->read(3));
+    }
+
     public static function dataSendFile(): array
     {
         $txtFilePath = self::getFilePath('answer.txt');
@@ -264,6 +326,29 @@ final class DownloadResponseFactoryTest extends TestCase
         $this->assertSame("x; }\n", (string) $response->getBody());
     }
 
+    public function testSendContentAsFileWithSingleByteRangeRequest(): void
+    {
+        $response = $this
+            ->getDownloadResponseFactory()
+            ->sendContentAsFile(
+                'abcdef',
+                'alphabet.txt',
+                mimeType: 'text/plain',
+                request: $this->createRequest('bytes=0-0'),
+            );
+
+        $this->assertSame(206, $response->getStatusCode());
+        $this->assertResponseHeaders(
+            [
+                'Accept-Ranges' => 'bytes',
+                'Content-Range' => 'bytes 0-0/6',
+                'Content-Length' => '1',
+            ],
+            $response,
+        );
+        $this->assertSame('a', (string) $response->getBody());
+    }
+
     public function testSendContentAsFileWithCaseInsensitiveRangeUnit(): void
     {
         $response = $this
@@ -308,6 +393,210 @@ final class DownloadResponseFactoryTest extends TestCase
             $response,
         );
         $this->assertSame('def', (string) $response->getBody());
+    }
+
+    public function testSendContentAsFileWithFullSuffixRangeRequest(): void
+    {
+        $response = $this
+            ->getDownloadResponseFactory()
+            ->sendContentAsFile(
+                'abcdef',
+                'alphabet.txt',
+                mimeType: 'text/plain',
+                request: $this->createRequest('bytes=-6'),
+            );
+
+        $this->assertSame(206, $response->getStatusCode());
+        $this->assertResponseHeaders(
+            [
+                'Accept-Ranges' => 'bytes',
+                'Content-Range' => 'bytes 0-5/6',
+                'Content-Length' => '6',
+            ],
+            $response,
+        );
+        $this->assertSame('abcdef', (string) $response->getBody());
+    }
+
+    public function testSendContentAsFileWithZeroSuffixRangeRequest(): void
+    {
+        $response = $this
+            ->getDownloadResponseFactory()
+            ->sendContentAsFile(
+                'abcdef',
+                'alphabet.txt',
+                mimeType: 'text/plain',
+                request: $this->createRequest('bytes=-0'),
+            );
+
+        $this->assertSame(416, $response->getStatusCode());
+        $this->assertResponseHeaders(
+            [
+                'Accept-Ranges' => 'bytes',
+                'Content-Range' => 'bytes */6',
+                'Content-Length' => '0',
+            ],
+            $response,
+        );
+        $this->assertSame('', (string) $response->getBody());
+    }
+
+    public function testSendContentAsFileWithRangeEndGreaterThanContentSize(): void
+    {
+        $response = $this
+            ->getDownloadResponseFactory()
+            ->sendContentAsFile(
+                'abcdef',
+                'alphabet.txt',
+                mimeType: 'text/plain',
+                request: $this->createRequest('bytes=4-99'),
+            );
+
+        $this->assertSame(206, $response->getStatusCode());
+        $this->assertResponseHeaders(
+            [
+                'Accept-Ranges' => 'bytes',
+                'Content-Range' => 'bytes 4-5/6',
+                'Content-Length' => '2',
+            ],
+            $response,
+        );
+        $this->assertSame('ef', (string) $response->getBody());
+    }
+
+    public function testSendContentAsFileWithWhitespaceAroundRangeRequest(): void
+    {
+        $response = $this
+            ->getDownloadResponseFactory()
+            ->sendContentAsFile(
+                'abcdef',
+                'alphabet.txt',
+                mimeType: 'text/plain',
+                request: $this->createRequest(' bytes=1-3 '),
+            );
+
+        $this->assertSame(206, $response->getStatusCode());
+        $this->assertResponseHeaders(
+            [
+                'Accept-Ranges' => 'bytes',
+                'Content-Range' => 'bytes 1-3/6',
+                'Content-Length' => '3',
+            ],
+            $response,
+        );
+        $this->assertSame('bcd', (string) $response->getBody());
+    }
+
+    public function testSendContentAsFileWithRangeBodyReadByChunks(): void
+    {
+        $body = $this
+            ->getDownloadResponseFactory()
+            ->sendContentAsFile(
+                'abcdef',
+                'alphabet.txt',
+                mimeType: 'text/plain',
+                request: $this->createRequest('bytes=1-4'),
+            )
+            ->getBody();
+
+        $this->assertSame(4, $body->getSize());
+        $this->assertSame(0, $body->tell());
+        $this->assertSame('bc', $body->read(2));
+        $this->assertSame(2, $body->tell());
+        $this->assertFalse($body->eof());
+        $this->assertSame('de', $body->read(10));
+        $this->assertSame(4, $body->tell());
+        $this->assertTrue($body->eof());
+        $this->assertSame('', $body->read(1));
+    }
+
+    public function testSendContentAsFileWithRangeBodyCanSeekAndRewind(): void
+    {
+        $body = $this
+            ->getDownloadResponseFactory()
+            ->sendContentAsFile(
+                'abcdef',
+                'alphabet.txt',
+                mimeType: 'text/plain',
+                request: $this->createRequest('bytes=2-5'),
+            )
+            ->getBody();
+
+        $this->assertSame('c', $body->read(1));
+        $body->seek(2);
+        $this->assertSame('e', $body->read(1));
+        $body->seek(-1, SEEK_END);
+        $this->assertSame('f', $body->read(1));
+        $body->rewind();
+        $this->assertSame('cdef', $body->getContents());
+    }
+
+    public function testSendContentAsFileWithRangeBodyCanSeekFromCurrentPosition(): void
+    {
+        $body = $this
+            ->getDownloadResponseFactory()
+            ->sendContentAsFile(
+                'abcdef',
+                'alphabet.txt',
+                mimeType: 'text/plain',
+                request: $this->createRequest('bytes=1-5'),
+            )
+            ->getBody();
+
+        $this->assertSame('b', $body->read(1));
+        $body->seek(2, SEEK_CUR);
+        $this->assertSame('e', $body->read(1));
+    }
+
+    public function testSendContentAsFileWithRangeBodyCanSeekToEnd(): void
+    {
+        $body = $this
+            ->getDownloadResponseFactory()
+            ->sendContentAsFile(
+                'abcdef',
+                'alphabet.txt',
+                mimeType: 'text/plain',
+                request: $this->createRequest('bytes=1-5'),
+            )
+            ->getBody();
+
+        $body->seek(0, SEEK_END);
+
+        $this->assertSame(5, $body->tell());
+        $this->assertTrue($body->eof());
+        $this->assertSame('', $body->read(1));
+    }
+
+    public function testSendContentAsFileWithRangeBodyStringCastRewindsBody(): void
+    {
+        $body = $this
+            ->getDownloadResponseFactory()
+            ->sendContentAsFile(
+                'abcdef',
+                'alphabet.txt',
+                mimeType: 'text/plain',
+                request: $this->createRequest('bytes=1-4'),
+            )
+            ->getBody();
+
+        $this->assertSame('bc', $body->read(2));
+        $this->assertSame('bcde', (string) $body);
+    }
+
+    public function testSendContentAsFileWithRangeBodyZeroLengthRead(): void
+    {
+        $body = $this
+            ->getDownloadResponseFactory()
+            ->sendContentAsFile(
+                'abcdef',
+                'alphabet.txt',
+                mimeType: 'text/plain',
+                request: $this->createRequest('bytes=1-4'),
+            )
+            ->getBody();
+
+        $this->assertSame('', $body->read(0));
+        $this->assertSame(0, $body->tell());
     }
 
     public function testSendContentAsFileWithUnsupportedRangeRequest(): void
@@ -358,6 +647,38 @@ final class DownloadResponseFactoryTest extends TestCase
         $this->assertSame('abcdef', (string) $response->getBody());
     }
 
+    public function testSendContentAsFileWithMalformedRangeRequestPrefix(): void
+    {
+        $response = $this
+            ->getDownloadResponseFactory()
+            ->sendContentAsFile(
+                'abcdef',
+                'alphabet.txt',
+                mimeType: 'text/plain',
+                request: $this->createRequest('bytes=foo1-3'),
+            );
+
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('', $response->getHeaderLine('Content-Range'));
+        $this->assertSame('abcdef', (string) $response->getBody());
+    }
+
+    public function testSendContentAsFileWithMalformedRangeRequestSuffix(): void
+    {
+        $response = $this
+            ->getDownloadResponseFactory()
+            ->sendContentAsFile(
+                'abcdef',
+                'alphabet.txt',
+                mimeType: 'text/plain',
+                request: $this->createRequest('bytes=1-3foo'),
+            );
+
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('', $response->getHeaderLine('Content-Range'));
+        $this->assertSame('abcdef', (string) $response->getBody());
+    }
+
     public function testSendContentAsFileWithEmptyMalformedRangeRequest(): void
     {
         $response = $this
@@ -381,6 +702,52 @@ final class DownloadResponseFactoryTest extends TestCase
         $this->assertSame('abcdef', (string) $response->getBody());
     }
 
+    public function testSendContentAsFileWithSuffixRangeRequestGreaterThanContentSize(): void
+    {
+        $response = $this
+            ->getDownloadResponseFactory()
+            ->sendContentAsFile(
+                'abcdef',
+                'alphabet.txt',
+                mimeType: 'text/plain',
+                request: $this->createRequest('bytes=-99'),
+            );
+
+        $this->assertSame(206, $response->getStatusCode());
+        $this->assertResponseHeaders(
+            [
+                'Accept-Ranges' => 'bytes',
+                'Content-Range' => 'bytes 0-5/6',
+                'Content-Length' => '6',
+            ],
+            $response,
+        );
+        $this->assertSame('abcdef', (string) $response->getBody());
+    }
+
+    public function testSendContentAsFileWithRangeRequestForEmptyContent(): void
+    {
+        $response = $this
+            ->getDownloadResponseFactory()
+            ->sendContentAsFile(
+                '',
+                'empty.txt',
+                mimeType: 'text/plain',
+                request: $this->createRequest('bytes=-1'),
+            );
+
+        $this->assertSame(416, $response->getStatusCode());
+        $this->assertResponseHeaders(
+            [
+                'Accept-Ranges' => 'bytes',
+                'Content-Range' => 'bytes */0',
+                'Content-Length' => '0',
+            ],
+            $response,
+        );
+        $this->assertSame('', (string) $response->getBody());
+    }
+
     public function testSendFileWithUnsatisfiableRangeRequest(): void
     {
         $response = $this
@@ -392,6 +759,29 @@ final class DownloadResponseFactoryTest extends TestCase
             [
                 'Accept-Ranges' => 'bytes',
                 'Content-Range' => 'bytes */3',
+                'Content-Length' => '0',
+            ],
+            $response,
+        );
+        $this->assertSame('', (string) $response->getBody());
+    }
+
+    public function testSendContentAsFileWithExplicitRangeStartingAtContentSize(): void
+    {
+        $response = $this
+            ->getDownloadResponseFactory()
+            ->sendContentAsFile(
+                'abcdef',
+                'alphabet.txt',
+                mimeType: 'text/plain',
+                request: $this->createRequest('bytes=6-6'),
+            );
+
+        $this->assertSame(416, $response->getStatusCode());
+        $this->assertResponseHeaders(
+            [
+                'Accept-Ranges' => 'bytes',
+                'Content-Range' => 'bytes */6',
                 'Content-Length' => '0',
             ],
             $response,
@@ -478,6 +868,97 @@ final class DownloadResponseFactoryTest extends TestCase
         $request = (new ServerRequestFactory())->createServerRequest('GET', '/');
 
         return $range === null ? $request : $request->withHeader('Range', $range);
+    }
+
+    private function createNonSeekableStream(string $content): StreamInterface
+    {
+        return new class ($content) implements StreamInterface {
+            private int $position = 0;
+
+            public function __construct(private readonly string $content)
+            {
+            }
+
+            public function __toString(): string
+            {
+                return $this->content;
+            }
+
+            public function close(): void
+            {
+            }
+
+            public function detach()
+            {
+                return null;
+            }
+
+            public function getSize(): ?int
+            {
+                return strlen($this->content);
+            }
+
+            public function tell(): int
+            {
+                return $this->position;
+            }
+
+            public function eof(): bool
+            {
+                return $this->position >= strlen($this->content);
+            }
+
+            public function isSeekable(): bool
+            {
+                return false;
+            }
+
+            public function seek(int $offset, int $whence = SEEK_SET): void
+            {
+                throw new RuntimeException('Stream is not seekable.');
+            }
+
+            public function rewind(): void
+            {
+                throw new RuntimeException('Stream is not seekable.');
+            }
+
+            public function isWritable(): bool
+            {
+                return false;
+            }
+
+            public function write(string $string): int
+            {
+                throw new RuntimeException('Stream is not writable.');
+            }
+
+            public function isReadable(): bool
+            {
+                return true;
+            }
+
+            public function read(int $length): string
+            {
+                $contents = substr($this->content, $this->position, $length);
+                $this->position += strlen($contents);
+
+                return $contents;
+            }
+
+            public function getContents(): string
+            {
+                $contents = substr($this->content, $this->position);
+                $this->position = strlen($this->content);
+
+                return $contents;
+            }
+
+            public function getMetadata(?string $key = null)
+            {
+                return $key === null ? [] : null;
+            }
+        };
     }
 
     private static function getFilePath(string $fileName): string

--- a/tests/DownloadResponseFactoryTest.php
+++ b/tests/DownloadResponseFactoryTest.php
@@ -332,6 +332,29 @@ final class DownloadResponseFactoryTest extends TestCase
         $this->assertSame('abcdef', (string) $response->getBody());
     }
 
+    public function testSendContentAsFileWithEmptyMalformedRangeRequest(): void
+    {
+        $response = $this
+            ->getDownloadResponseFactory()
+            ->sendContentAsFile(
+                'abcdef',
+                'alphabet.txt',
+                mimeType: 'text/plain',
+                request: $this->createRequest('bytes=-'),
+            );
+
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertResponseHeaders(
+            [
+                'Accept-Ranges' => 'bytes',
+                'Content-Length' => '6',
+            ],
+            $response,
+        );
+        $this->assertSame('', $response->getHeaderLine('Content-Range'));
+        $this->assertSame('abcdef', (string) $response->getBody());
+    }
+
     public function testSendFileWithUnsatisfiableRangeRequest(): void
     {
         $response = $this

--- a/tests/DownloadResponseFactoryTest.php
+++ b/tests/DownloadResponseFactoryTest.php
@@ -5,10 +5,12 @@ declare(strict_types=1);
 namespace Yiisoft\ResponseDownload\Tests;
 
 use HttpSoft\Message\ResponseFactory;
+use HttpSoft\Message\ServerRequestFactory;
 use HttpSoft\Message\StreamFactory;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
 use RuntimeException;
 use Yiisoft\Http\ContentDispositionHeader;
 use Yiisoft\ResponseDownload\DownloadResponseFactory;
@@ -198,6 +200,110 @@ final class DownloadResponseFactoryTest extends TestCase
         $responseFactory->sendFile($filePath);
     }
 
+    public function testSendFileWithRangeRequest(): void
+    {
+        $response = $this
+            ->getDownloadResponseFactory()
+            ->sendFile(self::getFilePath('style.css'), request: $this->createRequest('bytes=7-15'));
+
+        $this->assertSame(206, $response->getStatusCode());
+        $this->assertResponseHeaders(
+            [
+                'Accept-Ranges' => 'bytes',
+                'Content-Range' => 'bytes 7-15/26',
+                'Content-Length' => '9',
+                'Content-Disposition' => 'attachment; filename="style.css"',
+                'Content-Type' => 'text/css',
+            ],
+            $response,
+        );
+        $this->assertSame('font-size', (string) $response->getBody());
+    }
+
+    public function testSendFileWithOpenEndedRangeRequest(): void
+    {
+        $response = $this
+            ->getDownloadResponseFactory()
+            ->sendFile(self::getFilePath('style.css'), request: $this->createRequest('bytes=21-'));
+
+        $this->assertSame(206, $response->getStatusCode());
+        $this->assertResponseHeaders(
+            [
+                'Accept-Ranges' => 'bytes',
+                'Content-Range' => 'bytes 21-25/26',
+                'Content-Length' => '5',
+            ],
+            $response,
+        );
+        $this->assertSame("x; }\n", (string) $response->getBody());
+    }
+
+    public function testSendContentAsFileWithSuffixRangeRequest(): void
+    {
+        $response = $this
+            ->getDownloadResponseFactory()
+            ->sendContentAsFile(
+                'abcdef',
+                'alphabet.txt',
+                mimeType: 'text/plain',
+                request: $this->createRequest('bytes=-3'),
+            );
+
+        $this->assertSame(206, $response->getStatusCode());
+        $this->assertResponseHeaders(
+            [
+                'Accept-Ranges' => 'bytes',
+                'Content-Range' => 'bytes 3-5/6',
+                'Content-Length' => '3',
+            ],
+            $response,
+        );
+        $this->assertSame('def', (string) $response->getBody());
+    }
+
+    public function testSendContentAsFileWithUnsupportedRangeRequest(): void
+    {
+        $response = $this
+            ->getDownloadResponseFactory()
+            ->sendContentAsFile(
+                'abcdef',
+                'alphabet.txt',
+                mimeType: 'text/plain',
+                request: $this->createRequest('bytes=0-1,3-4'),
+            );
+
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertResponseHeaders(
+            [
+                'Accept-Ranges' => 'bytes',
+                'Content-Length' => '6',
+                'Content-Disposition' => 'attachment; filename="alphabet.txt"',
+                'Content-Type' => 'text/plain',
+            ],
+            $response,
+        );
+        $this->assertSame('', $response->getHeaderLine('Content-Range'));
+        $this->assertSame('abcdef', (string) $response->getBody());
+    }
+
+    public function testSendFileWithUnsatisfiableRangeRequest(): void
+    {
+        $response = $this
+            ->getDownloadResponseFactory()
+            ->sendFile(self::getFilePath('answer.txt'), request: $this->createRequest('bytes=3-'));
+
+        $this->assertSame(416, $response->getStatusCode());
+        $this->assertResponseHeaders(
+            [
+                'Accept-Ranges' => 'bytes',
+                'Content-Range' => 'bytes */3',
+                'Content-Length' => '0',
+            ],
+            $response,
+        );
+        $this->assertSame('', (string) $response->getBody());
+    }
+
     public static function dataSendContentAsFile(): array
     {
         $txtContent = '42';
@@ -270,6 +376,13 @@ final class DownloadResponseFactoryTest extends TestCase
         $streamFactory = new StreamFactory();
 
         return new DownloadResponseFactory($responseFactory, $streamFactory);
+    }
+
+    private function createRequest(?string $range = null): ServerRequestInterface
+    {
+        $request = (new ServerRequestFactory())->createServerRequest('GET', '/');
+
+        return $range === null ? $request : $request->withHeader('Range', $range);
     }
 
     private static function getFilePath(string $fileName): string


### PR DESCRIPTION
## Summary

- add optional request-aware byte range handling for download responses
- add bounded byte range stream for seekable response bodies
- document range request behavior