### PR TITLE
Harden GitHub workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,5 @@
 version: 2
 updates:
-  # Maintain dependencies for GitHub Actions.
 
   # Maintain dependencies for Composer
   - package-ecosystem: "composer"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,16 +1,8 @@
 version: 2
 updates:
-  # Maintain dependencies for GitHub Actions.
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "daily"
-    # Too noisy. See https://github.community/t/increase-if-necessary-for-github-actions-in-dependabot/179581
-    open-pull-requests-limit: 0
-
-  # Maintain dependencies for Composer
-  - package-ecosystem: "composer"
-    directory: "/"
-    schedule:
-      interval: "daily"
-    versioning-strategy: increase-if-necessary
+      interval: "weekly"
+    cooldown:
+      default-days: 7

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,8 @@ updates:
     open-pull-requests-limit: 0
 
   # Maintain dependencies for Composer
+    ignore:
+      - dependency-name: "yiisoft/*"
   - package-ecosystem: "composer"
     directory: "/"
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,11 @@
 version: 2
 updates:
+  # Maintain dependencies for GitHub Actions.
+  - package-ecosystem: "composer"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    versioning-strategy: increase-if-necessary
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,8 @@
 version: 2
 updates:
   # Maintain dependencies for GitHub Actions.
+
+  # Maintain dependencies for Composer
   - package-ecosystem: "composer"
     directory: "/"
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,3 +12,5 @@ updates:
       interval: "weekly"
     cooldown:
       default-days: 7
+    ignore:
+      - dependency-name: "yiisoft/*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,4 +15,6 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    cooldown:
+      default-days: 7
     versioning-strategy: increase-if-necessary

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,5 @@
 version: 2
 updates:
-
   # Maintain dependencies for Composer
   - package-ecosystem: "composer"
     directory: "/"

--- a/.github/workflows/bc.yml
+++ b/.github/workflows/bc.yml
@@ -27,7 +27,7 @@ permissions:
   contents: read
 jobs:
   roave_bc_check:
-    uses: yiisoft/actions/.github/workflows/bc.yml@ab62d6b3b0e0cff6c9724ec5a395bedb41c639a2
+    uses: yiisoft/actions/.github/workflows/bc.yml@master
     with:
       os: >-
         ['ubuntu-latest']

--- a/.github/workflows/bc.yml
+++ b/.github/workflows/bc.yml
@@ -23,9 +23,11 @@ on:
 
 name: backwards compatibility
 
+permissions:
+  contents: read
 jobs:
   roave_bc_check:
-    uses: yiisoft/actions/.github/workflows/bc.yml@master
+    uses: yiisoft/actions/.github/workflows/bc.yml@ab62d6b3b0e0cff6c9724ec5a395bedb41c639a2
     with:
       os: >-
         ['ubuntu-latest']

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,3 +32,5 @@ jobs:
       php: >-
         ['8.1', '8.2']
       extensions: 'fileinfo'
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ permissions:
   contents: read
 jobs:
   phpunit:
-    uses: yiisoft/actions/.github/workflows/phpunit.yml@ab62d6b3b0e0cff6c9724ec5a395bedb41c639a2
+    uses: yiisoft/actions/.github/workflows/phpunit.yml@master
     with:
       os: >-
         ['ubuntu-latest', 'windows-latest']

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,9 +21,11 @@ on:
 
 name: build
 
+permissions:
+  contents: read
 jobs:
   phpunit:
-    uses: yiisoft/actions/.github/workflows/phpunit.yml@master
+    uses: yiisoft/actions/.github/workflows/phpunit.yml@ab62d6b3b0e0cff6c9724ec5a395bedb41c639a2
     with:
       os: >-
         ['ubuntu-latest', 'windows-latest']

--- a/.github/workflows/composer-require-checker.yml
+++ b/.github/workflows/composer-require-checker.yml
@@ -23,9 +23,11 @@ on:
 
 name: Composer require checker
 
+permissions:
+  contents: read
 jobs:
   composer-require-checker:
-    uses: yiisoft/actions/.github/workflows/composer-require-checker.yml@master
+    uses: yiisoft/actions/.github/workflows/composer-require-checker.yml@ab62d6b3b0e0cff6c9724ec5a395bedb41c639a2
     with:
       os: >-
         ['ubuntu-latest']

--- a/.github/workflows/composer-require-checker.yml
+++ b/.github/workflows/composer-require-checker.yml
@@ -27,7 +27,7 @@ permissions:
   contents: read
 jobs:
   composer-require-checker:
-    uses: yiisoft/actions/.github/workflows/composer-require-checker.yml@ab62d6b3b0e0cff6c9724ec5a395bedb41c639a2
+    uses: yiisoft/actions/.github/workflows/composer-require-checker.yml@master
     with:
       os: >-
         ['ubuntu-latest']

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -24,7 +24,7 @@ permissions:
   contents: read
 jobs:
   mutation:
-    uses: yiisoft/actions/.github/workflows/infection.yml@ab62d6b3b0e0cff6c9724ec5a395bedb41c639a2
+    uses: yiisoft/actions/.github/workflows/infection.yml@master
     with:
       os: >-
         ['ubuntu-latest']

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -20,9 +20,11 @@ on:
 
 name: mutation test
 
+permissions:
+  contents: read
 jobs:
   mutation:
-    uses: yiisoft/actions/.github/workflows/infection.yml@master
+    uses: yiisoft/actions/.github/workflows/infection.yml@ab62d6b3b0e0cff6c9724ec5a395bedb41c639a2
     with:
       os: >-
         ['ubuntu-latest']

--- a/.github/workflows/rector.yml
+++ b/.github/workflows/rector.yml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 jobs:
   rector:
-    uses: yiisoft/actions/.github/workflows/rector.yml@ab62d6b3b0e0cff6c9724ec5a395bedb41c639a2
+    uses: yiisoft/actions/.github/workflows/rector.yml@master
     with:
       os: >-
         ['ubuntu-latest']

--- a/.github/workflows/rector.yml
+++ b/.github/workflows/rector.yml
@@ -11,9 +11,11 @@ on:
 
 name: rector
 
+permissions:
+  contents: read
 jobs:
   rector:
-    uses: yiisoft/actions/.github/workflows/rector.yml@master
+    uses: yiisoft/actions/.github/workflows/rector.yml@ab62d6b3b0e0cff6c9724ec5a395bedb41c639a2
     with:
       os: >-
         ['ubuntu-latest']

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -22,9 +22,11 @@ on:
 
 name: static analysis
 
+permissions:
+  contents: read
 jobs:
   psalm:
-    uses: yiisoft/actions/.github/workflows/psalm.yml@master
+    uses: yiisoft/actions/.github/workflows/psalm.yml@ab62d6b3b0e0cff6c9724ec5a395bedb41c639a2
     with:
       os: >-
         ['ubuntu-latest']

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -26,7 +26,7 @@ permissions:
   contents: read
 jobs:
   psalm:
-    uses: yiisoft/actions/.github/workflows/psalm.yml@ab62d6b3b0e0cff6c9724ec5a395bedb41c639a2
+    uses: yiisoft/actions/.github/workflows/psalm.yml@master
     with:
       os: >-
         ['ubuntu-latest']

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -14,8 +14,8 @@ on:
       - '.github/**.yaml'
 
 permissions:
-  actions: read
-  contents: read
+  actions: read # Required by zizmor when reading workflow metadata through the API.
+  contents: read # Required to read workflow files.
 
 jobs:
   zizmor:

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,37 @@
+name: GitHub Actions Security Analysis with zizmor 🌈
+
+on:
+    push:
+        branches:
+            - main
+        paths:
+            - '.github/**.yml'
+            - '.github/**.yaml'
+    pull_request:
+        paths:
+            - '.github/**.yml'
+            - '.github/**.yaml'
+
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+
+permissions:
+    contents: read
+
+jobs:
+    zizmor:
+        name: Run zizmor 🌈
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+              with:
+                  persist-credentials: false
+
+            - name: Run zizmor 🌈
+              uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6
+              with:
+                  advanced-security: false
+                  annotations: true
+                  persona: 'pedantic'

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,5 @@
+rules:
+  unpinned-uses:
+    config:
+      policies:
+        "yiisoft/*": any

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,5 +1,0 @@
-rules:
-  unpinned-uses:
-    config:
-      policies:
-        "yiisoft/*": any

--- a/src/DownloadResponseFactory.php
+++ b/src/DownloadResponseFactory.php
@@ -332,13 +332,8 @@ final class DownloadResponseFactory
     private function getContentMimeType(string $content): string
     {
         $info = new finfo(FILEINFO_MIME_TYPE);
-        $mimeType = @$info->buffer($content);
 
-        if (!$mimeType) {
-            $mimeType = self::MIME_APPLICATION_OCTET_STREAM;
-        }
-
-        return $mimeType;
+        return @$info->buffer($content) ?: self::MIME_APPLICATION_OCTET_STREAM;
     }
 
     /**

--- a/tests/DownloadResponseFactoryTest.php
+++ b/tests/DownloadResponseFactoryTest.php
@@ -14,6 +14,7 @@ use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\StreamInterface;
 use RuntimeException;
 use Yiisoft\Http\ContentDispositionHeader;
+use Yiisoft\ResponseDownload\ByteRangeStream;
 use Yiisoft\ResponseDownload\DownloadResponseFactory;
 
 final class DownloadResponseFactoryTest extends TestCase
@@ -804,6 +805,156 @@ final class DownloadResponseFactoryTest extends TestCase
             $response,
         );
         $this->assertSame('', (string) $response->getBody());
+    }
+
+    public function testSendContentAsFileWithRangeEndBeforeRangeStart(): void
+    {
+        $response = $this
+            ->getDownloadResponseFactory()
+            ->sendContentAsFile(
+                'abcdef',
+                'alphabet.txt',
+                mimeType: 'text/plain',
+                request: $this->createRequest('bytes=4-2'),
+            );
+
+        $this->assertSame(416, $response->getStatusCode());
+        $this->assertResponseHeaders(
+            [
+                'Accept-Ranges' => 'bytes',
+                'Content-Range' => 'bytes */6',
+                'Content-Length' => '0',
+            ],
+            $response,
+        );
+        $this->assertSame('', (string) $response->getBody());
+    }
+
+    public function testByteRangeStreamRejectsInvalidRange(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Invalid byte range.');
+
+        new ByteRangeStream((new StreamFactory())->createStream('abcdef'), 3, 2);
+    }
+
+    public function testByteRangeStreamRejectsNonSeekableStream(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Stream is not seekable.');
+
+        new ByteRangeStream($this->createNonSeekableStream('abcdef'), 1, 3);
+    }
+
+    public function testByteRangeStreamRejectsNonReadableStream(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Stream is not readable.');
+
+        new ByteRangeStream($this->createNonReadableSeekableStream('abcdef'), 1, 3);
+    }
+
+    public function testByteRangeStreamRejectsInvalidSeekMode(): void
+    {
+        $body = new ByteRangeStream((new StreamFactory())->createStream('abcdef'), 1, 3);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Invalid seek mode.');
+
+        $body->seek(0, 999);
+    }
+
+    public function testByteRangeStreamRejectsInvalidSeekOffset(): void
+    {
+        $body = new ByteRangeStream((new StreamFactory())->createStream('abcdef'), 1, 3);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Invalid seek offset.');
+
+        $body->seek(4);
+    }
+
+    public function testByteRangeStreamRejectsNegativeReadLength(): void
+    {
+        $body = new ByteRangeStream((new StreamFactory())->createStream('abcdef'), 1, 3);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Length parameter cannot be negative.');
+
+        $body->read(-1);
+    }
+
+    public function testByteRangeStreamRejectsWrite(): void
+    {
+        $body = new ByteRangeStream((new StreamFactory())->createStream('abcdef'), 1, 3);
+
+        $this->assertFalse($body->isWritable());
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Stream is not writable.');
+
+        $body->write('x');
+    }
+
+    public function testByteRangeStreamDelegatesCloseDetachAndMetadata(): void
+    {
+        $resource = fopen('php://memory', 'rb');
+        $stream = $this->createMock(StreamInterface::class);
+        $stream->method('isSeekable')->willReturn(true);
+        $stream->method('isReadable')->willReturn(true);
+        $stream->expects($this->once())->method('seek')->with(1);
+        $stream->expects($this->once())->method('close');
+        $stream->expects($this->once())->method('detach')->willReturn($resource);
+        $stream->expects($this->exactly(2))
+            ->method('getMetadata')
+            ->willReturnMap(
+                [
+                    [null, ['uri' => 'php://memory']],
+                    ['uri', 'php://memory'],
+                ],
+            );
+
+        $body = new ByteRangeStream($stream, 1, 3);
+
+        $this->assertTrue($body->isSeekable());
+        $this->assertTrue($body->isReadable());
+        $this->assertSame(['uri' => 'php://memory'], $body->getMetadata());
+        $this->assertSame('php://memory', $body->getMetadata('uri'));
+        $this->assertSame($resource, $body->detach());
+
+        $body->close();
+        fclose($resource);
+    }
+
+    public function testByteRangeStreamStringCastReturnsEmptyStringOnFailure(): void
+    {
+        $calls = 0;
+        $stream = $this->createMock(StreamInterface::class);
+        $stream->method('isSeekable')->willReturn(true);
+        $stream->method('isReadable')->willReturn(true);
+        $stream->method('seek')->willReturnCallback(
+            static function () use (&$calls): void {
+                if (++$calls > 1) {
+                    throw new RuntimeException('Unable to seek.');
+                }
+            },
+        );
+
+        $body = new ByteRangeStream($stream, 1, 3);
+
+        $this->assertSame('', (string) $body);
+    }
+
+    public function testByteRangeStreamGetContentsStopsWhenUnderlyingStreamReturnsEmptyChunk(): void
+    {
+        $stream = $this->createMock(StreamInterface::class);
+        $stream->method('isSeekable')->willReturn(true);
+        $stream->method('isReadable')->willReturn(true);
+        $stream->method('eof')->willReturn(false);
+        $stream->method('read')->willReturn('');
+
+        $body = new ByteRangeStream($stream, 1, 3);
+
+        $this->assertSame('', $body->getContents());
     }
 
     public static function dataSendContentAsFile(): array


### PR DESCRIPTION
## Summary
- Pin GitHub Actions and reusable Yii workflow references
- Restrict workflow token permissions where applicable
- Disable checkout credential persistence where it is not needed
- Replace floating service image refs where zizmor flagged them

## Validation
- zizmor --no-progress --no-exit-codes .github/workflows
- git diff --check